### PR TITLE
Handling ui notification more idiomatically

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
@@ -8,6 +8,7 @@ import com.example.android.architecture.blueprints.todoapp.util.schedulers.BaseS
 import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 
+import static com.example.android.architecture.blueprints.todoapp.util.ObservableUtils.pairWithDelay;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TaskDetailActionProcessorHolder {
@@ -44,7 +45,9 @@ public class TaskDetailActionProcessorHolder {
             action -> mTasksRepository.completeTask(action.taskId())
                     .andThen(mTasksRepository.getTask(action.taskId()))
                     .toObservable()
-                    .map(TaskDetailResult.CompleteTaskResult::success)
+                    .flatMap(task -> pairWithDelay(
+                            TaskDetailResult.CompleteTaskResult.success(task),
+                            TaskDetailResult.CompleteTaskResult.hideUiNotification()))
                     .onErrorReturn(TaskDetailResult.CompleteTaskResult::failure)
                     .subscribeOn(mSchedulerProvider.io())
                     .observeOn(mSchedulerProvider.ui())
@@ -55,7 +58,9 @@ public class TaskDetailActionProcessorHolder {
             action -> mTasksRepository.activateTask(action.taskId())
                     .andThen(mTasksRepository.getTask(action.taskId()))
                     .toObservable()
-                    .map(TaskDetailResult.ActivateTaskResult::success)
+                    .flatMap(task -> pairWithDelay(
+                            TaskDetailResult.ActivateTaskResult.success(task),
+                            TaskDetailResult.ActivateTaskResult.hideUiNotification()))
                     .onErrorReturn(TaskDetailResult.ActivateTaskResult::failure)
                     .subscribeOn(mSchedulerProvider.io())
                     .observeOn(mSchedulerProvider.ui())

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
@@ -45,9 +45,10 @@ public class TaskDetailActionProcessorHolder {
             action -> mTasksRepository.completeTask(action.taskId())
                     .andThen(mTasksRepository.getTask(action.taskId()))
                     .toObservable()
-                    .flatMap(task -> pairWithDelay(
-                            TaskDetailResult.CompleteTaskResult.success(task),
-                            TaskDetailResult.CompleteTaskResult.hideUiNotification()))
+                    .flatMap(task ->
+                            pairWithDelay(
+                                    TaskDetailResult.CompleteTaskResult.success(task),
+                                    TaskDetailResult.CompleteTaskResult.hideUiNotification()))
                     .onErrorReturn(TaskDetailResult.CompleteTaskResult::failure)
                     .subscribeOn(mSchedulerProvider.io())
                     .observeOn(mSchedulerProvider.ui())
@@ -58,9 +59,10 @@ public class TaskDetailActionProcessorHolder {
             action -> mTasksRepository.activateTask(action.taskId())
                     .andThen(mTasksRepository.getTask(action.taskId()))
                     .toObservable()
-                    .flatMap(task -> pairWithDelay(
-                            TaskDetailResult.ActivateTaskResult.success(task),
-                            TaskDetailResult.ActivateTaskResult.hideUiNotification()))
+                    .flatMap(task ->
+                            pairWithDelay(
+                                    TaskDetailResult.ActivateTaskResult.success(task),
+                                    TaskDetailResult.ActivateTaskResult.hideUiNotification()))
                     .onErrorReturn(TaskDetailResult.ActivateTaskResult::failure)
                     .subscribeOn(mSchedulerProvider.io())
                     .observeOn(mSchedulerProvider.ui())

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -169,16 +169,16 @@ public class TaskDetailFragment extends Fragment implements MviView<TaskDetailIn
 
         showActive(state.active());
 
-        if (state.taskComplete()){
+        if (state.taskComplete()) {
             showTaskMarkedComplete();
         }
 
-        if (state.taskActivated()){
+        if (state.taskActivated()) {
             showTaskMarkedActive();
         }
 
-        if (state.taskDeleted()){
-            showTaskDeleted();
+        if (state.taskDeleted()) {
+            getActivity().finish();
         }
 
     }
@@ -226,7 +226,7 @@ public class TaskDetailFragment extends Fragment implements MviView<TaskDetailIn
         mDetailTitle.setVisibility(View.GONE);
     }
 
-    public void showActive(boolean isActive){
+    public void showActive(boolean isActive) {
         mDetailCompleteStatus.setChecked(!isActive);
     }
 
@@ -239,10 +239,6 @@ public class TaskDetailFragment extends Fragment implements MviView<TaskDetailIn
         Intent intent = new Intent(getContext(), AddEditTaskActivity.class);
         intent.putExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID, taskId);
         startActivityForResult(intent, REQUEST_EDIT_TASK);
-    }
-
-    public void showTaskDeleted() {
-        getActivity().finish();
     }
 
     public void showTaskMarkedComplete() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailResult.java
@@ -4,13 +4,16 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.example.android.architecture.blueprints.todoapp.data.Task;
-import com.example.android.architecture.blueprints.todoapp.util.LceStatus;
 import com.example.android.architecture.blueprints.todoapp.mvibase.MviResult;
+import com.example.android.architecture.blueprints.todoapp.util.LceStatus;
+import com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus;
 import com.google.auto.value.AutoValue;
 
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.FAILURE;
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.IN_FLIGHT;
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.SUCCESS;
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.HIDE;
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.SHOW;
 
 interface TaskDetailResult extends MviResult {
 
@@ -54,24 +57,32 @@ interface TaskDetailResult extends MviResult {
         abstract LceStatus status();
 
         @Nullable
+        abstract UiNotificationStatus uiNotificationStatus();
+
+        @Nullable
         abstract Task task();
 
         @Nullable
         abstract Throwable error();
 
         @NonNull
+        static ActivateTaskResult hideUiNotification() {
+            return new AutoValue_TaskDetailResult_ActivateTaskResult(SUCCESS, HIDE, null, null);
+        }
+
+        @NonNull
         static ActivateTaskResult success(@NonNull Task task) {
-            return new AutoValue_TaskDetailResult_ActivateTaskResult(SUCCESS, task, null);
+            return new AutoValue_TaskDetailResult_ActivateTaskResult(SUCCESS, SHOW, task, null);
         }
 
         @NonNull
         static ActivateTaskResult failure(Throwable error) {
-            return new AutoValue_TaskDetailResult_ActivateTaskResult(FAILURE, null, error);
+            return new AutoValue_TaskDetailResult_ActivateTaskResult(FAILURE, null, null, error);
         }
 
         @NonNull
         static ActivateTaskResult inFlight() {
-            return new AutoValue_TaskDetailResult_ActivateTaskResult(IN_FLIGHT, null, null);
+            return new AutoValue_TaskDetailResult_ActivateTaskResult(IN_FLIGHT, null, null, null);
         }
     }
 
@@ -81,24 +92,32 @@ interface TaskDetailResult extends MviResult {
         abstract LceStatus status();
 
         @Nullable
+        abstract UiNotificationStatus uiNotificationStatus();
+
+        @Nullable
         abstract Task task();
 
         @Nullable
         abstract Throwable error();
 
         @NonNull
+        static CompleteTaskResult hideUiNotification() {
+            return new AutoValue_TaskDetailResult_CompleteTaskResult(SUCCESS, HIDE, null, null);
+        }
+
+        @NonNull
         static CompleteTaskResult success(@NonNull Task task) {
-            return new AutoValue_TaskDetailResult_CompleteTaskResult(SUCCESS, task, null);
+            return new AutoValue_TaskDetailResult_CompleteTaskResult(SUCCESS, SHOW, task, null);
         }
 
         @NonNull
         static CompleteTaskResult failure(Throwable error) {
-            return new AutoValue_TaskDetailResult_CompleteTaskResult(FAILURE, null, error);
+            return new AutoValue_TaskDetailResult_CompleteTaskResult(FAILURE, null, null, error);
         }
 
         @NonNull
         static CompleteTaskResult inFlight() {
-            return new AutoValue_TaskDetailResult_CompleteTaskResult(IN_FLIGHT, null, null);
+            return new AutoValue_TaskDetailResult_CompleteTaskResult(IN_FLIGHT, null, null, null);
         }
     }
 
@@ -112,12 +131,12 @@ interface TaskDetailResult extends MviResult {
 
         @NonNull
         static DeleteTaskResult success() {
-            return new AutoValue_TaskDetailResult_DeleteTaskResult(SUCCESS,  null);
+            return new AutoValue_TaskDetailResult_DeleteTaskResult(SUCCESS, null);
         }
 
         @NonNull
         static DeleteTaskResult failure(Throwable error) {
-            return new AutoValue_TaskDetailResult_DeleteTaskResult(FAILURE,  error);
+            return new AutoValue_TaskDetailResult_DeleteTaskResult(FAILURE, error);
         }
 
         @NonNull

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
@@ -27,6 +27,7 @@ import io.reactivex.Observable;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.subjects.PublishSubject;
 
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.SHOW;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -144,11 +145,11 @@ public class TaskDetailViewModel extends ViewModel
                             (TaskDetailResult.DeleteTaskResult) result;
                     switch (deleteTaskResult.status()) {
                         case SUCCESS:
-                            return stateBuilder.taskDeleted(false).build();
-                        case FAILURE:
-                            return stateBuilder.taskDeleted(false).error(deleteTaskResult.error()).build();
-                        case IN_FLIGHT:
                             return stateBuilder.taskDeleted(true).build();
+                        case FAILURE:
+                            return stateBuilder.error(deleteTaskResult.error()).build();
+                        case IN_FLIGHT:
+                            return stateBuilder.build();
                     }
                 } else if (result instanceof TaskDetailResult.ActivateTaskResult) {
                     TaskDetailResult.ActivateTaskResult activateTaskResult =
@@ -156,16 +157,14 @@ public class TaskDetailViewModel extends ViewModel
                     switch (activateTaskResult.status()) {
                         case SUCCESS:
                             return stateBuilder
-                                    .taskActivated(false)
+                                    .taskActivated(activateTaskResult.uiNotificationStatus() == SHOW)
                                     .active(true)
                                     .build();
 
                         case FAILURE:
-                            return stateBuilder
-                                    .taskActivated(false)
-                                    .error(activateTaskResult.error()).build();
+                            return stateBuilder.error(activateTaskResult.error()).build();
                         case IN_FLIGHT:
-                            return stateBuilder.taskActivated(true).build();
+                            return stateBuilder.build();
                     }
                 } else if (result instanceof TaskDetailResult.CompleteTaskResult) {
                     TaskDetailResult.CompleteTaskResult completeTaskResult =
@@ -173,16 +172,14 @@ public class TaskDetailViewModel extends ViewModel
                     switch (completeTaskResult.status()) {
                         case SUCCESS:
                             return stateBuilder
-                                    .taskComplete(false)
+                                    .taskComplete(completeTaskResult.uiNotificationStatus() == SHOW)
                                     .active(false)
                                     .build();
 
                         case FAILURE:
-                            return stateBuilder
-                                    .taskComplete(false)
-                                    .error(completeTaskResult.error()).build();
+                            return stateBuilder.error(completeTaskResult.error()).build();
                         case IN_FLIGHT:
-                            return stateBuilder.taskComplete(true).build();
+                            return stateBuilder.build();
                     }
                 }
                 throw new IllegalStateException("Mishandled result? Should not happen―as always: " + result);

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActionProcessorHolder.java
@@ -5,11 +5,10 @@ import android.support.annotation.NonNull;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 import com.example.android.architecture.blueprints.todoapp.util.schedulers.BaseSchedulerProvider;
 
-import java.util.concurrent.TimeUnit;
-
 import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 
+import static com.example.android.architecture.blueprints.todoapp.util.ObservableUtils.pairWithDelay;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TasksActionProcessorHolder {
@@ -98,11 +97,4 @@ public class TasksActionProcessorHolder {
                                     && !(v instanceof TasksAction.ClearCompletedTasksAction))
                                     .flatMap(w -> Observable.error(
                                             new IllegalArgumentException("Unknown Action type: " + w)))));
-
-    private <T> Observable<T> pairWithDelay(T immediate, T delayed) {
-        return Observable.timer(2, TimeUnit.SECONDS)
-                .take(1)
-                .map(ignored -> delayed)
-                .startWith(immediate);
-    }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksResult.java
@@ -96,24 +96,32 @@ interface TasksResult extends MviResult {
         abstract LceStatus status();
 
         @Nullable
+        abstract UiNotificationStatus uiNotificationStatus();
+
+        @Nullable
         abstract List<Task> tasks();
 
         @Nullable
         abstract Throwable error();
 
         @NonNull
+        static CompleteTaskResult hideUiNotification() {
+            return new AutoValue_TasksResult_CompleteTaskResult(SUCCESS, HIDE, null, null);
+        }
+
+        @NonNull
         static CompleteTaskResult success(@NonNull List<Task> tasks) {
-            return new AutoValue_TasksResult_CompleteTaskResult(SUCCESS, tasks, null);
+            return new AutoValue_TasksResult_CompleteTaskResult(SUCCESS, SHOW, tasks, null);
         }
 
         @NonNull
         static CompleteTaskResult failure(Throwable error) {
-            return new AutoValue_TasksResult_CompleteTaskResult(FAILURE, null, error);
+            return new AutoValue_TasksResult_CompleteTaskResult(FAILURE, null, null, error);
         }
 
         @NonNull
         static CompleteTaskResult inFlight() {
-            return new AutoValue_TasksResult_CompleteTaskResult(IN_FLIGHT, null, null);
+            return new AutoValue_TasksResult_CompleteTaskResult(IN_FLIGHT, null, null, null);
         }
     }
 
@@ -123,24 +131,32 @@ interface TasksResult extends MviResult {
         abstract LceStatus status();
 
         @Nullable
+        abstract UiNotificationStatus uiNotificationStatus();
+
+        @Nullable
         abstract List<Task> tasks();
 
         @Nullable
         abstract Throwable error();
 
         @NonNull
+        static ClearCompletedTasksResult hideUiNotification() {
+            return new AutoValue_TasksResult_ClearCompletedTasksResult(SUCCESS, HIDE, null, null);
+        }
+
+        @NonNull
         static ClearCompletedTasksResult success(@NonNull List<Task> tasks) {
-            return new AutoValue_TasksResult_ClearCompletedTasksResult(SUCCESS, tasks, null);
+            return new AutoValue_TasksResult_ClearCompletedTasksResult(SUCCESS, SHOW, tasks, null);
         }
 
         @NonNull
         static ClearCompletedTasksResult failure(Throwable error) {
-            return new AutoValue_TasksResult_ClearCompletedTasksResult(FAILURE, null, error);
+            return new AutoValue_TasksResult_ClearCompletedTasksResult(FAILURE, null, null, error);
         }
 
         @NonNull
         static ClearCompletedTasksResult inFlight() {
-            return new AutoValue_TasksResult_ClearCompletedTasksResult(IN_FLIGHT, null, null);
+            return new AutoValue_TasksResult_ClearCompletedTasksResult(IN_FLIGHT, null, null, null);
         }
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksResult.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.mvibase.MviResult;
 import com.example.android.architecture.blueprints.todoapp.util.LceStatus;
+import com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus;
 import com.google.auto.value.AutoValue;
 
 import java.util.List;
@@ -13,6 +14,8 @@ import java.util.List;
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.FAILURE;
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.IN_FLIGHT;
 import static com.example.android.architecture.blueprints.todoapp.util.LceStatus.SUCCESS;
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.HIDE;
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.SHOW;
 
 interface TasksResult extends MviResult {
     @AutoValue
@@ -58,24 +61,32 @@ interface TasksResult extends MviResult {
         abstract LceStatus status();
 
         @Nullable
+        abstract UiNotificationStatus uiNotificationStatus();
+
+        @Nullable
         abstract List<Task> tasks();
 
         @Nullable
         abstract Throwable error();
 
         @NonNull
+        static ActivateTaskResult hideUiNotification() {
+            return new AutoValue_TasksResult_ActivateTaskResult(SUCCESS, HIDE, null, null);
+        }
+
+        @NonNull
         static ActivateTaskResult success(@NonNull List<Task> tasks) {
-            return new AutoValue_TasksResult_ActivateTaskResult(SUCCESS, tasks, null);
+            return new AutoValue_TasksResult_ActivateTaskResult(SUCCESS, SHOW, tasks, null);
         }
 
         @NonNull
         static ActivateTaskResult failure(Throwable error) {
-            return new AutoValue_TasksResult_ActivateTaskResult(FAILURE, null, error);
+            return new AutoValue_TasksResult_ActivateTaskResult(FAILURE, null, null, error);
         }
 
         @NonNull
         static ActivateTaskResult inFlight() {
-            return new AutoValue_TasksResult_ActivateTaskResult(IN_FLIGHT, null, null);
+            return new AutoValue_TasksResult_ActivateTaskResult(IN_FLIGHT, null, null, null);
         }
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
@@ -30,6 +30,7 @@ import io.reactivex.Observable;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.subjects.PublishSubject;
 
+import static com.example.android.architecture.blueprints.todoapp.util.UiNotificationStatus.SHOW;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -150,13 +151,18 @@ public class TasksViewModel extends ViewModel implements MviViewModel<TasksInten
                             (TasksResult.ActivateTaskResult) result;
                     switch (activateTaskResult.status()) {
                         case SUCCESS:
-                            List<Task> tasks = filteredTasks(checkNotNull(activateTaskResult.tasks()),
-                                    previousState.tasksFilterType());
-                            return stateBuilder.taskActivated(false).tasks(tasks).build();
+                            stateBuilder.taskActivated(activateTaskResult.uiNotificationStatus() == SHOW);
+                            if (activateTaskResult.tasks() != null) {
+                                List<Task> tasks =
+                                        filteredTasks(checkNotNull(activateTaskResult.tasks()),
+                                                previousState.tasksFilterType());
+                                stateBuilder.tasks(tasks);
+                            }
+                            return stateBuilder.build();
                         case FAILURE:
-                            return stateBuilder.taskActivated(false).error(activateTaskResult.error()).build();
+                            return stateBuilder.error(activateTaskResult.error()).build();
                         case IN_FLIGHT:
-                            return stateBuilder.taskActivated(true).build();
+                            return stateBuilder.build();
                     }
                 } else if (result instanceof TasksResult.ClearCompletedTasksResult) {
                     TasksResult.ClearCompletedTasksResult clearCompletedTasks =

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
@@ -138,13 +138,18 @@ public class TasksViewModel extends ViewModel implements MviViewModel<TasksInten
                             (TasksResult.CompleteTaskResult) result;
                     switch (completeTaskResult.status()) {
                         case SUCCESS:
-                            List<Task> tasks = filteredTasks(checkNotNull(completeTaskResult.tasks()),
-                                    previousState.tasksFilterType());
-                            return stateBuilder.taskComplete(false).tasks(tasks).build();
+                            stateBuilder.taskComplete(completeTaskResult.uiNotificationStatus() == SHOW);
+                            if (completeTaskResult.tasks() != null) {
+                                List<Task> tasks =
+                                        filteredTasks(checkNotNull(completeTaskResult.tasks()),
+                                                previousState.tasksFilterType());
+                                stateBuilder.tasks(tasks);
+                            }
+                            return stateBuilder.build();
                         case FAILURE:
-                            return stateBuilder.taskComplete(false).error(completeTaskResult.error()).build();
+                            return stateBuilder.error(completeTaskResult.error()).build();
                         case IN_FLIGHT:
-                            return stateBuilder.taskComplete(true).build();
+                            return stateBuilder.build();
                     }
                 } else if (result instanceof TasksResult.ActivateTaskResult) {
                     TasksResult.ActivateTaskResult activateTaskResult =
@@ -169,15 +174,18 @@ public class TasksViewModel extends ViewModel implements MviViewModel<TasksInten
                             (TasksResult.ClearCompletedTasksResult) result;
                     switch (clearCompletedTasks.status()) {
                         case SUCCESS:
-                            List<Task> tasks = filteredTasks(checkNotNull(clearCompletedTasks.tasks()),
-                                    previousState.tasksFilterType());
-                            return stateBuilder.completedTasksCleared(false).tasks(tasks).build();
+                            stateBuilder.completedTasksCleared(clearCompletedTasks.uiNotificationStatus() == SHOW);
+                            if (clearCompletedTasks.tasks() != null) {
+                                List<Task> tasks =
+                                        filteredTasks(checkNotNull(clearCompletedTasks.tasks()),
+                                                previousState.tasksFilterType());
+                                stateBuilder.tasks(tasks);
+                            }
+                            return stateBuilder.build();
                         case FAILURE:
-                            return stateBuilder.completedTasksCleared(false)
-                                    .error(clearCompletedTasks.error())
-                                    .build();
+                            return stateBuilder.error(clearCompletedTasks.error()).build();
                         case IN_FLIGHT:
-                            return stateBuilder.completedTasksCleared(true).build();
+                            return stateBuilder.build();
                     }
                 } else {
                     throw new IllegalArgumentException("Don't know this result " + result);

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ObservableUtils.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ObservableUtils.java
@@ -1,0 +1,18 @@
+package com.example.android.architecture.blueprints.todoapp.util;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Observable;
+
+public class ObservableUtils {
+    private ObservableUtils() {
+        // no implementation
+    }
+
+    public static <T> Observable<T> pairWithDelay(T immediate, T delayed) {
+        return Observable.timer(2, TimeUnit.SECONDS)
+                .take(1)
+                .map(ignored -> delayed)
+                .startWith(immediate);
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/UiNotificationStatus.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/UiNotificationStatus.java
@@ -1,0 +1,10 @@
+package com.example.android.architecture.blueprints.todoapp.util;
+
+/**
+ * Switch value used for displaying ui notifications.
+ * If SHOW, then display a notification,
+ * if NONE, hide it or do nothing.
+ */
+public enum UiNotificationStatus {
+    SHOW, HIDE
+}

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.java
@@ -97,7 +97,7 @@ public class TaskDetailViewModelTest {
 
         // Then a task is saved in the repository and the view updates
         verify(mTasksRepository).deleteTask(anyString()); // saved to the model
-        mTestObserver.assertValueAt(0, TaskDetailViewState::taskDeleted);
+        mTestObserver.assertValueAt(1, TaskDetailViewState::taskDeleted);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class TaskDetailViewModelTest {
         // Then a task is saved in the repository and the view updates
         verify(mTasksRepository).completeTask(anyString());
         verify(mTasksRepository).getTask(anyString());
-        mTestObserver.assertValueAt(0, TaskDetailViewState::taskComplete);
+        mTestObserver.assertValueAt(1, TaskDetailViewState::taskComplete);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TaskDetailViewModelTest {
         // Then a task is saved in the repository and the view updates
         verify(mTasksRepository).activateTask(anyString());
         verify(mTasksRepository).getTask(anyString());
-        mTestObserver.assertValueAt(0, TaskDetailViewState::taskActivated);
+        mTestObserver.assertValueAt(1, TaskDetailViewState::taskActivated);
     }
 
     @Test

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.java
@@ -125,7 +125,7 @@ public class TasksViewModelTest {
         // Then repository is called and task marked complete state is emitted
         verify(mTasksRepository).completeTask(task);
         verify(mTasksRepository).getTasks();
-        mTestObserver.assertValueAt(0, TasksViewState::taskComplete);
+        mTestObserver.assertValueAt(1, TasksViewState::taskComplete);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class TasksViewModelTest {
         // Then repository is called and task marked active state is emitted
         verify(mTasksRepository).activateTask(task);
         verify(mTasksRepository).getTasks();
-        mTestObserver.assertValueAt(0, TasksViewState::taskActivated);
+        mTestObserver.assertValueAt(1, TasksViewState::taskActivated);
     }
 
     @Test


### PR DESCRIPTION
This PR tries to fix the confusion around UI notifications (`snackbar`) and their state management.

- The UI notification state is not bound to the `Result`'s `LceStatus` anymore. A new `uiNotificationStatus` has been created to manage it.
- The UI notification state is managed inside the `ViewModel`: on success result, the notification displaying _trigger_ (`uiNotificationStatus`) is set to `SHOW`; 2s later, an other success result is emitted with the _trigger_ set back to `HIDE`.

At the moment, `HIDE` does not affect anything but the code could be refactored so that `snackbar`s would be displayed for an undefined period of time (`LENGTH_INDEFINITE`) and only a `HIDE` event would actually dismiss it. I don't have a strong opinion about this right now.