### PR TITLE
Rebinding refactoring

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskAction.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskAction.java
@@ -40,9 +40,9 @@ interface AddEditTaskAction extends MviAction {
     }
 
     @AutoValue
-    abstract class GetLastState implements AddEditTaskAction {
-        public static GetLastState create() {
-            return new AutoValue_AddEditTaskAction_GetLastState();
+    abstract class SkipMe implements AddEditTaskAction {
+        public static SkipMe create() {
+            return new AutoValue_AddEditTaskAction_SkipMe();
         }
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActionProcessorHolder.java
@@ -53,22 +53,16 @@ public class AddEditTaskActionProcessorHolder {
                     new Task(action.title(), action.description(), action.taskId()))
                     .andThen(Observable.just(AddEditTaskResult.UpdateTask.create())));
 
-    private ObservableTransformer<AddEditTaskAction.GetLastState, AddEditTaskResult.GetLastState>
-            getLastStateProcessor =
-            actions -> actions.map(ignored -> AddEditTaskResult.GetLastState.create());
-
     ObservableTransformer<AddEditTaskAction, AddEditTaskResult> actionProcessor =
             actions -> actions.publish(shared -> Observable.merge(
                     shared.ofType(AddEditTaskAction.PopulateTask.class).compose(populateTaskProcessor),
                     shared.ofType(AddEditTaskAction.CreateTask.class).compose(createTaskProcessor),
-                    shared.ofType(AddEditTaskAction.UpdateTask.class).compose(updateTaskProcessor),
-                    shared.ofType(AddEditTaskAction.GetLastState.class).compose(getLastStateProcessor))
+                    shared.ofType(AddEditTaskAction.UpdateTask.class).compose(updateTaskProcessor))
                     .mergeWith(
                             // Error for not implemented actions
                             shared.filter(v -> !(v instanceof AddEditTaskAction.PopulateTask) &&
                                     !(v instanceof AddEditTaskAction.CreateTask) &&
-                                    !(v instanceof AddEditTaskAction.UpdateTask) &&
-                                    !(v instanceof AddEditTaskAction.GetLastState))
+                                    !(v instanceof AddEditTaskAction.UpdateTask))
                                     .flatMap(w -> Observable.error(
                                             new IllegalArgumentException("Unknown Action type: " + w)))));
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskIntent.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskIntent.java
@@ -18,13 +18,6 @@ interface AddEditTaskIntent extends MviIntent {
     }
 
     @AutoValue
-    abstract class GetLastState implements AddEditTaskIntent {
-        public static GetLastState create() {
-            return new AutoValue_AddEditTaskIntent_GetLastState();
-        }
-    }
-
-    @AutoValue
     abstract class SaveTask implements AddEditTaskIntent {
         @Nullable
         abstract String taskId();

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskResult.java
@@ -56,11 +56,4 @@ interface AddEditTaskResult extends MviResult {
             return new AutoValue_AddEditTaskResult_UpdateTask();
         }
     }
-
-    @AutoValue
-    abstract class GetLastState implements AddEditTaskResult {
-        static GetLastState create() {
-            return new AutoValue_AddEditTaskResult_GetLastState();
-        }
-    }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -39,7 +39,7 @@ public class AddEditTaskViewModel extends ViewModel
     @NonNull
     private PublishSubject<AddEditTaskIntent> mIntentsSubject;
     @NonNull
-    private PublishSubject<AddEditTaskViewState> mStatesSubject;
+    private Observable<AddEditTaskViewState> mStatesObservable;
     @NonNull
     private AddEditTaskActionProcessorHolder mActionProcessorHolder;
 
@@ -47,9 +47,7 @@ public class AddEditTaskViewModel extends ViewModel
         mActionProcessorHolder = checkNotNull(actionProcessorHolder);
 
         mIntentsSubject = PublishSubject.create();
-        mStatesSubject = PublishSubject.create();
-
-        compose().subscribe(this.mStatesSubject);
+        mStatesObservable = compose().replay(1).autoConnect(0).skip(1);
     }
 
     @Override
@@ -59,36 +57,31 @@ public class AddEditTaskViewModel extends ViewModel
 
     @Override
     public Observable<AddEditTaskViewState> states() {
-        return mStatesSubject;
+        return mStatesObservable;
     }
 
     private Observable<AddEditTaskViewState> compose() {
         return mIntentsSubject
-                .scan(initialIntentFilter)
+                // take only the first ever InitialIntent and all intents of other types
+                // to avoid reloading data on config changes
+                .publish(shared ->
+                        Observable.merge(
+                                shared.ofType(AddEditTaskIntent.InitialIntent.class).take(1),
+                                shared.filter(intent -> !(intent instanceof AddEditTaskIntent.InitialIntent))
+                        )
+                )
                 .map(this::actionFromIntent)
+                .filter(action -> !(action instanceof AddEditTaskAction.SkipMe))
                 .compose(mActionProcessorHolder.actionProcessor)
                 .scan(AddEditTaskViewState.idle(), reducer);
     }
-
-    private BiFunction<AddEditTaskIntent, AddEditTaskIntent, AddEditTaskIntent> initialIntentFilter =
-            (previousIntent, newIntent) -> {
-                // if isReConnection (e.g. after config change)
-                // i.e. we are inside the scan, meaning there has already
-                // been intent in the past, meaning the InitialIntent cannot
-                // be the first => it is a reconnection.
-                if (newIntent instanceof AddEditTaskIntent.InitialIntent) {
-                    return AddEditTaskIntent.GetLastState.create();
-                } else {
-                    return newIntent;
-                }
-            };
 
     private AddEditTaskAction actionFromIntent(MviIntent intent) {
         if (intent instanceof AddEditTaskIntent.InitialIntent) {
             String taskId = ((AddEditTaskIntent.InitialIntent) intent).taskId();
             if (taskId == null) {
-                // nothing to do here so getting the idle state with GetLastState intent
-                return AddEditTaskAction.GetLastState.create();
+                // new Task, so nothing to do
+                return AddEditTaskAction.SkipMe.create();
             } else {
                 return AddEditTaskAction.PopulateTask.create(taskId);
             }
@@ -104,18 +97,12 @@ public class AddEditTaskViewModel extends ViewModel
                         taskId, saveTaskIntent.title(), saveTaskIntent.description());
             }
         }
-        if (intent instanceof AddEditTaskIntent.GetLastState) {
-            return AddEditTaskAction.GetLastState.create();
-        }
         throw new IllegalArgumentException("do not know how to treat this intent " + intent);
     }
 
     private static BiFunction<AddEditTaskViewState, AddEditTaskResult, AddEditTaskViewState> reducer =
             (previousState, result) -> {
                 AddEditTaskViewState.Builder stateBuilder = previousState.buildWith();
-                if (result instanceof AddEditTaskResult.GetLastState) {
-                    return stateBuilder.build();
-                }
                 if (result instanceof AddEditTaskResult.PopulateTask) {
                     AddEditTaskResult.PopulateTask populateTaskResult =
                             (AddEditTaskResult.PopulateTask) result;

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -48,7 +48,7 @@ public class AddEditTaskViewModel extends ViewModel
         mActionProcessorHolder = checkNotNull(actionProcessorHolder);
 
         mIntentsSubject = PublishSubject.create();
-        mStatesObservable = compose().replay(1).autoConnect(0).skip(1);
+        mStatesObservable = compose().skip(1).replay(1).autoConnect(0);
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsAction.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsAction.java
@@ -10,11 +10,4 @@ interface StatisticsAction extends MviAction {
             return new AutoValue_StatisticsAction_LoadStatistics();
         }
     }
-
-    @AutoValue
-    abstract class GetLastState implements StatisticsAction {
-        public static GetLastState create() {
-            return new AutoValue_StatisticsAction_GetLastState();
-        }
-    }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsActionProcessorHolder.java
@@ -44,19 +44,10 @@ public class StatisticsActionProcessorHolder {
                             .observeOn(mSchedulerProvider.ui())
                             .startWith(StatisticsResult.LoadStatistics.inFlight()));
 
-    private ObservableTransformer<StatisticsAction.GetLastState, StatisticsResult.GetLastState>
-            getLastStateProcessor =
-            actions -> actions.map(ignored -> StatisticsResult.GetLastState.create());
 
     ObservableTransformer<StatisticsAction, StatisticsResult> actionProcessor =
-            actions -> actions.publish(shared -> Observable.merge(
-                    shared.ofType(StatisticsAction.LoadStatistics.class).compose(loadStatisticsProcessor),
-                    shared.ofType(StatisticsAction.GetLastState.class).compose(getLastStateProcessor))
-                    .mergeWith(
-                            // Error for not implemented actions
-                            shared.filter(v -> !(v instanceof StatisticsAction.LoadStatistics)
-                                    && !(v instanceof StatisticsAction.GetLastState))
-                                    .flatMap(w -> Observable.error(
-                                            new IllegalArgumentException("Unknown Action type: " + w)))));
+            actions -> actions.publish(shared ->
+                    shared.ofType(StatisticsAction.LoadStatistics.class).compose(loadStatisticsProcessor)
+            );
 
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsIntent.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsIntent.java
@@ -4,19 +4,10 @@ import com.example.android.architecture.blueprints.todoapp.mvibase.MviIntent;
 import com.google.auto.value.AutoValue;
 
 interface StatisticsIntent extends MviIntent {
-    // should we create a top singleton that any view could use?
     @AutoValue
     abstract class InitialIntent implements StatisticsIntent {
         public static InitialIntent create() {
             return new AutoValue_StatisticsIntent_InitialIntent();
-        }
-    }
-
-    // should we create a top singleton that any view could use?
-    @AutoValue
-    abstract class GetLastState implements StatisticsIntent {
-        public static GetLastState create() {
-            return new AutoValue_StatisticsIntent_GetLastState();
         }
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsResult.java
@@ -36,11 +36,4 @@ interface StatisticsResult extends MviResult {
             return new AutoValue_StatisticsResult_LoadStatistics(LceStatus.IN_FLIGHT, 0, 0, null);
         }
     }
-
-    @AutoValue
-    abstract class GetLastState implements StatisticsResult {
-        static GetLastState create() {
-            return new AutoValue_StatisticsResult_GetLastState();
-        }
-    }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
@@ -46,7 +46,7 @@ public class StatisticsViewModel extends ViewModel
         this.mActionProcessorHolder = checkNotNull(actionProcessorHolder, "actionProcessorHolder cannot be null");
 
         mIntentsSubject = PublishSubject.create();
-        mStatesObservable = compose().replay(1).autoConnect(0).skip(1);
+        mStatesObservable = compose().skip(1).replay(1).autoConnect(0);
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
@@ -23,6 +23,7 @@ import com.example.android.architecture.blueprints.todoapp.mvibase.MviIntent;
 import com.example.android.architecture.blueprints.todoapp.mvibase.MviViewModel;
 
 import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.subjects.PublishSubject;
 
@@ -37,7 +38,7 @@ public class StatisticsViewModel extends ViewModel
     @NonNull
     private PublishSubject<StatisticsIntent> mIntentsSubject;
     @NonNull
-    private PublishSubject<StatisticsViewState> mStatesSubject;
+    private Observable<StatisticsViewState> mStatesObservable;
     @NonNull
     private StatisticsActionProcessorHolder mActionProcessorHolder;
 
@@ -45,9 +46,7 @@ public class StatisticsViewModel extends ViewModel
         this.mActionProcessorHolder = checkNotNull(actionProcessorHolder, "actionProcessorHolder cannot be null");
 
         mIntentsSubject = PublishSubject.create();
-        mStatesSubject = PublishSubject.create();
-
-        compose().subscribe(this.mStatesSubject);
+        mStatesObservable = compose().replay(1).autoConnect(0).skip(1);
     }
 
     @Override
@@ -57,36 +56,32 @@ public class StatisticsViewModel extends ViewModel
 
     @Override
     public Observable<StatisticsViewState> states() {
-        return mStatesSubject;
+        return mStatesObservable;
     }
 
     private Observable<StatisticsViewState> compose() {
         return mIntentsSubject
-                .scan(initialIntentFilter)
+                .compose(intentFilter)
                 .map(this::actionFromIntent)
                 .compose(mActionProcessorHolder.actionProcessor)
                 .scan(StatisticsViewState.idle(), reducer);
     }
 
-    private BiFunction<StatisticsIntent, StatisticsIntent, StatisticsIntent> initialIntentFilter =
-            (previousIntent, newIntent) -> {
-                // if isReConnection (e.g. after config change)
-                // i.e. we are inside the scan, meaning there has already
-                // been intent in the past, meaning the InitialIntent cannot
-                // be the first => it is a reconnection.
-                if (newIntent instanceof StatisticsIntent.InitialIntent) {
-                    return StatisticsIntent.GetLastState.create();
-                } else {
-                    return newIntent;
-                }
-            };
+    /**
+     * take only the first ever InitialIntent and all intents of other types
+     * to avoid reloading data on config changes
+     */
+    private ObservableTransformer<StatisticsIntent, StatisticsIntent> intentFilter =
+            intents -> intents.publish(shared ->
+                    Observable.merge(
+                            shared.ofType(StatisticsIntent.InitialIntent.class).take(1),
+                            shared.filter(intent -> !(intent instanceof StatisticsIntent.InitialIntent))
+                    )
+            );
 
     private StatisticsAction actionFromIntent(MviIntent intent) {
         if (intent instanceof StatisticsIntent.InitialIntent) {
             return StatisticsAction.LoadStatistics.create();
-        }
-        if (intent instanceof StatisticsIntent.GetLastState) {
-            return StatisticsAction.GetLastState.create();
         }
         throw new IllegalArgumentException("do not know how to treat this intent " + intent);
     }
@@ -107,8 +102,6 @@ public class StatisticsViewModel extends ViewModel
                         case IN_FLIGHT:
                             return stateBuilder.isLoading(true).build();
                     }
-                } else if (result instanceof StatisticsResult.GetLastState) {
-                    return stateBuilder.build();
                 } else {
                     throw new IllegalArgumentException("Don't know this result " + result);
                 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailAction.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailAction.java
@@ -42,11 +42,4 @@ interface TaskDetailAction extends MviAction {
             return new AutoValue_TaskDetailAction_CompleteTask(taskId);
         }
     }
-
-    @AutoValue
-    abstract class GetLastState implements TaskDetailAction {
-        public static GetLastState create() {
-            return new AutoValue_TaskDetailAction_GetLastState();
-        }
-    }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActionProcessorHolder.java
@@ -35,11 +35,6 @@ public class TaskDetailActionProcessorHolder {
                     .observeOn(mSchedulerProvider.ui())
                     .startWith(TaskDetailResult.PopulateTask.inFlight()));
 
-
-    private ObservableTransformer<TaskDetailAction.GetLastState, TaskDetailResult.GetLastState>
-            getLastStateProcessor =
-            actions -> actions.map(ignored -> TaskDetailResult.GetLastState.create());
-
     private ObservableTransformer<TaskDetailAction.CompleteTask, TaskDetailResult.CompleteTaskResult>
             completeTaskProcessor = actions -> actions.flatMap(
             action -> mTasksRepository.completeTask(action.taskId())
@@ -82,10 +77,7 @@ public class TaskDetailActionProcessorHolder {
                     shared.ofType(TaskDetailAction.PopulateTask.class).compose(populateTaskProcessor),
                     shared.ofType(TaskDetailAction.CompleteTask.class).compose(completeTaskProcessor),
                     shared.ofType(TaskDetailAction.ActivateTask.class).compose(activateTaskProcessor))
-                    .mergeWith(
-                            Observable.merge(
-                                    shared.ofType(TaskDetailAction.DeleteTask.class).compose(deleteTaskProcessor),
-                                    shared.ofType(TaskDetailAction.GetLastState.class).compose(getLastStateProcessor))
+                    .mergeWith(shared.ofType(TaskDetailAction.DeleteTask.class).compose(deleteTaskProcessor)
 
                     )
                     .mergeWith(
@@ -93,8 +85,7 @@ public class TaskDetailActionProcessorHolder {
                             shared.filter(v -> !(v instanceof TaskDetailAction.PopulateTask) &&
                                     !(v instanceof TaskDetailAction.CompleteTask) &&
                                     !(v instanceof TaskDetailAction.ActivateTask) &&
-                                    !(v instanceof TaskDetailAction.DeleteTask) &&
-                                    !(v instanceof TaskDetailAction.GetLastState))
+                                    !(v instanceof TaskDetailAction.DeleteTask))
                                     .flatMap(w -> Observable.error(
                                             new IllegalArgumentException("Unknown Action type: " + w)))));
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailIntent.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailIntent.java
@@ -17,13 +17,6 @@ interface TaskDetailIntent extends MviIntent {
     }
 
     @AutoValue
-    abstract class GetLastState implements TaskDetailIntent {
-        public static GetLastState create() {
-            return new AutoValue_TaskDetailIntent_GetLastState();
-        }
-    }
-
-    @AutoValue
     abstract class DeleteTask implements TaskDetailIntent {
 
         abstract String taskId();

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailResult.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailResult.java
@@ -45,13 +45,6 @@ interface TaskDetailResult extends MviResult {
     }
 
     @AutoValue
-    abstract class GetLastState implements TaskDetailResult {
-        static GetLastState create() {
-            return new AutoValue_TaskDetailResult_GetLastState();
-        }
-    }
-
-    @AutoValue
     abstract class ActivateTaskResult implements TaskDetailResult {
         @NonNull
         abstract LceStatus status();


### PR DESCRIPTION
This PR refactors how the view model sent back the latest state to the view on rebinding (rotation, config changes...).

### Before

When the view binds to the view model, nothing happens. The view would have emitted an initial intent and the view model would have detected a "not first ever" initial intent and transformed it to a `GetLastIntent` that would go through the whole data flow and forces a emission of the lasted cached state.

### After

The view model emits automatically the latest state on binding (except the first time). When the view emits its initial intent, only the first ever goes through the data flow and others are ignored.  
No more `GetLastXxx` !