### PR TITLE
FIX: disposing render subscription after onDestroyView

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -55,12 +55,6 @@ public class AddEditTaskFragment extends Fragment implements MviView<AddEditTask
         return new AddEditTaskFragment();
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        mDisposables.dispose();
-    }
-
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
@@ -82,7 +76,19 @@ public class AddEditTaskFragment extends Fragment implements MviView<AddEditTask
         mViewModel = ViewModelProviders.of(this, ToDoViewModelFactory.getInstance(getContext()))
                 .get(AddEditTaskViewModel.class);
         mDisposables = new CompositeDisposable();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
         bind();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mDisposables.clear();
     }
 
     /**

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
@@ -68,6 +68,12 @@ public class StatisticsFragment extends Fragment
         mViewModel = ViewModelProviders.of(this, ToDoViewModelFactory.getInstance(getContext()))
                 .get(StatisticsViewModel.class);
         mDisposables = new CompositeDisposable();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
         bind();
     }
 
@@ -85,9 +91,9 @@ public class StatisticsFragment extends Fragment
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        mDisposables.dispose();
+    public void onStop() {
+        super.onStop();
+        mDisposables.clear();
     }
 
     @Override

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -103,8 +103,15 @@ public class TaskDetailFragment extends Fragment implements MviView<TaskDetailIn
         mViewModel = ViewModelProviders.of(this, ToDoViewModelFactory.getInstance(getContext()))
                 .get(TaskDetailViewModel.class);
         mDisposables = new CompositeDisposable();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
         bind();
     }
+
 
     /**
      * Connect the {@link MviView} with the {@link MviViewModel}
@@ -124,9 +131,9 @@ public class TaskDetailFragment extends Fragment implements MviView<TaskDetailIn
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        mDisposables.dispose();
+    public void onStop() {
+        super.onStop();
+        mDisposables.clear();
     }
 
     @Override

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
@@ -101,6 +101,12 @@ public class TasksFragment extends Fragment
 
         mViewModel = ViewModelProviders.of(this, ToDoViewModelFactory.getInstance(getContext()))
                 .get(TasksViewModel.class);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
         bind();
     }
 
@@ -129,10 +135,9 @@ public class TasksFragment extends Fragment
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        mDisposables.dispose();
+    public void onStop() {
+        super.onStop();
+        mDisposables.clear();
     }
 
     @Override


### PR DESCRIPTION
This fix is created to make sure the render function is not called after the view is destroyed but the onDestroy lifecycle function has never got called. it fixes the issue #44 for the Java branch