### PR TITLE
FIX: disposing render subscription after onDestroyView

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
@@ -99,7 +99,7 @@ class AddEditTaskFragment : Fragment(), MviView<AddEditTaskIntent, AddEditTaskVi
 
   override fun onStop() {
     super.onStop()
-    disposables.dispose()
+    disposables.clear()
   }
 
   /**

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
@@ -55,11 +55,6 @@ class AddEditTaskFragment : Fragment(), MviView<AddEditTaskIntent, AddEditTaskVi
   private val argumentTaskId: String?
     get() = arguments?.getString(ARGUMENT_EDIT_TASK_ID)
 
-  override fun onDestroy() {
-    super.onDestroy()
-    disposables.dispose()
-  }
-
   override fun onCreateView(
       inflater: LayoutInflater,
       container: ViewGroup?,
@@ -77,6 +72,10 @@ class AddEditTaskFragment : Fragment(), MviView<AddEditTaskIntent, AddEditTaskVi
     super.onViewCreated(view, savedInstanceState)
     fab = activity!!.findViewById(R.id.fab_edit_task_done)
     fab.setImageResource(R.drawable.ic_done)
+  }
+
+  override fun onStart() {
+    super.onStart()
 
     bind()
   }
@@ -96,6 +95,11 @@ class AddEditTaskFragment : Fragment(), MviView<AddEditTaskIntent, AddEditTaskVi
 
   override fun intents(): Observable<AddEditTaskIntent> {
     return Observable.merge(initialIntent(), saveTaskIntent())
+  }
+
+  override fun onStop() {
+    super.onStop()
+    disposables.dispose()
   }
 
   /**

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
@@ -55,8 +55,8 @@ class StatisticsFragment : Fragment(), MviView<StatisticsIntent, StatisticsViewS
         .also { statisticsTV = it.findViewById(R.id.statistics) }
   }
 
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
+  override fun onStart() {
+    super.onStart()
     bind()
   }
 
@@ -75,8 +75,8 @@ class StatisticsFragment : Fragment(), MviView<StatisticsIntent, StatisticsViewS
     viewModel.processIntents(intents())
   }
 
-  override fun onDestroy() {
-    super.onDestroy()
+  override fun onStop() {
+    super.onStop()
     disposables.dispose()
   }
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
@@ -77,7 +77,7 @@ class StatisticsFragment : Fragment(), MviView<StatisticsIntent, StatisticsViewS
 
   override fun onStop() {
     super.onStop()
-    disposables.dispose()
+    disposables.clear()
   }
 
   override fun intents(): Observable<StatisticsIntent> = initialIntent()

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
@@ -87,8 +87,8 @@ class TaskDetailFragment : Fragment(), MviView<TaskDetailIntent, TaskDetailViewS
     return root
   }
 
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
+  override fun onStart() {
+    super.onStart()
 
     bind()
   }
@@ -110,8 +110,8 @@ class TaskDetailFragment : Fragment(), MviView<TaskDetailIntent, TaskDetailViewS
         .subscribe { showEditTask(argumentTaskId) }
   }
 
-  override fun onDestroy() {
-    super.onDestroy()
+  override fun onStop() {
+    super.onStop()
     disposables.dispose()
   }
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
@@ -112,7 +112,7 @@ class TaskDetailFragment : Fragment(), MviView<TaskDetailIntent, TaskDetailViewS
 
   override fun onStop() {
     super.onStop()
-    disposables.dispose()
+    disposables.clear()
   }
 
   override fun intents(): Observable<TaskDetailIntent> {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -88,11 +88,8 @@ class TasksFragment : Fragment(), MviView<TasksIntent, TasksViewState> {
     listAdapter = TasksAdapter(ArrayList(0))
   }
 
-  override fun onViewCreated(
-    view: View,
-    savedInstanceState: Bundle?
-  ) {
-    super.onViewCreated(view, savedInstanceState)
+  override fun onStart() {
+    super.onStart()
 
     bind()
   }
@@ -120,8 +117,8 @@ class TasksFragment : Fragment(), MviView<TasksIntent, TasksViewState> {
     refreshIntentPublisher.onNext(TasksIntent.RefreshIntent(false))
   }
 
-  override fun onDestroy() {
-    super.onDestroy()
+  override fun onStop() {
+    super.onStop()
 
     disposables.dispose()
   }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -120,7 +120,7 @@ class TasksFragment : Fragment(), MviView<TasksIntent, TasksViewState> {
   override fun onStop() {
     super.onStop()
 
-    disposables.dispose()
+    disposables.clear()
   }
 
   override fun onActivityResult(


### PR DESCRIPTION
This fix is created to make sure the render function is not called after the view is destroyed but the onDestroy lifecycle function has never got called. it fixes the issue #44 for the Kotlin branch