### PR TITLE
Clear intentsSubject subscription before subscribe to prevent multiple subcriptions

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -33,6 +33,7 @@ import com.example.android.architecture.blueprints.todoapp.mvibase.MviViewState
 import com.example.android.architecture.blueprints.todoapp.util.notOfType
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.PublishSubject
 
@@ -52,6 +53,7 @@ class AddEditTaskViewModel(
    * while the UI disconnects and reconnects on config changes.
    */
   private val intentsSubject: PublishSubject<AddEditTaskIntent> = PublishSubject.create()
+  private val compositeDisposable = CompositeDisposable()
   private val statesObservable: Observable<AddEditTaskViewState> = compose()
 
   /**
@@ -69,7 +71,8 @@ class AddEditTaskViewModel(
     }
 
   override fun processIntents(intents: Observable<AddEditTaskIntent>) {
-    intents.subscribe(intentsSubject)
+    compositeDisposable.clear()
+    compositeDisposable.add(intents.subscribe(intentsSubject::onNext))
   }
 
   override fun states(): Observable<AddEditTaskViewState> = statesObservable

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
@@ -31,6 +31,7 @@ import com.example.android.architecture.blueprints.todoapp.statistics.Statistics
 import com.example.android.architecture.blueprints.todoapp.util.notOfType
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.PublishSubject
 
@@ -50,6 +51,7 @@ class StatisticsViewModel(
    * while the UI disconnects and reconnects on config changes.
    */
   private val intentsSubject: PublishSubject<StatisticsIntent> = PublishSubject.create()
+  private val compositeDisposable = CompositeDisposable()
   private val statesObservable: Observable<StatisticsViewState> = compose()
 
   /**
@@ -67,7 +69,8 @@ class StatisticsViewModel(
     }
 
   override fun processIntents(intents: Observable<StatisticsIntent>) {
-    intents.subscribe(intentsSubject)
+    compositeDisposable.clear()
+    compositeDisposable.add(intents.subscribe(intentsSubject::onNext))
   }
 
   override fun states(): Observable<StatisticsViewState> = statesObservable

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -37,6 +37,7 @@ import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetail
 import com.example.android.architecture.blueprints.todoapp.util.notOfType
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.PublishSubject
 
@@ -56,6 +57,7 @@ class TaskDetailViewModel(
    * while the UI disconnects and reconnects on config changes.
    */
   private val intentsSubject: PublishSubject<TaskDetailIntent> = PublishSubject.create()
+  private val compositeDisposable = CompositeDisposable()
   private val statesObservable: Observable<TaskDetailViewState> = compose()
 
   /**
@@ -73,7 +75,8 @@ class TaskDetailViewModel(
     }
 
   override fun processIntents(intents: Observable<TaskDetailIntent>) {
-    intents.subscribe(intentsSubject)
+    compositeDisposable.clear()
+    compositeDisposable.add(intents.subscribe(intentsSubject::onNext))
   }
 
   override fun states(): Observable<TaskDetailViewState> = statesObservable

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -41,6 +41,7 @@ import com.example.android.architecture.blueprints.todoapp.tasks.TasksViewState.
 import com.example.android.architecture.blueprints.todoapp.util.notOfType
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.PublishSubject
 
@@ -61,6 +62,7 @@ class TasksViewModel(
    * while the UI disconnects and reconnects on config changes.
    */
   private val intentsSubject: PublishSubject<TasksIntent> = PublishSubject.create()
+  private val compositeDisposable = CompositeDisposable()
   private val statesObservable: Observable<TasksViewState> = compose()
 
   /**
@@ -78,7 +80,8 @@ class TasksViewModel(
     }
 
   override fun processIntents(intents: Observable<TasksIntent>) {
-    intents.subscribe(intentsSubject)
+    compositeDisposable.clear()
+    compositeDisposable.add(intents.subscribe(intentsSubject::onNext))
   }
 
   override fun states(): Observable<TasksViewState> = statesObservable


### PR DESCRIPTION
This PR aim to fix this issue https://github.com/oldergod/android-architecture/issues/49.

Because `viewModel.processIntents()` is called on fragment's `onStart`, multiple subscription is possible. Thus, we need to clear the subscription before adding a new one.